### PR TITLE
Send Cache-Control header for images

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ minix.newEndpoint("/image/",function(req,res) {
       if(e) return HandleError(e,req)
     })
     res.setHeader("Content-Type","image/svg+xml")
+    res.setHeader("Cache-Control", "max-age=300, public")
     props.name = url[2]==='_'?url[3]:url[2]+"/"+url[3];
     res.end(badge(props))
   })


### PR DESCRIPTION
Sends a `Cache-Control` header set to a cache timeout of 5 minutes (same as the local cache in dockeri.co), this is mostly for Cloudflare to play nice with caching banners.
